### PR TITLE
[Concept Detection] Use ';' as concept delimiter in f1_compute

### DIFF
--- a/concept_detection/concept_detection_evaluator.py
+++ b/concept_detection/concept_detection_evaluator.py
@@ -155,12 +155,12 @@ class ConceptDetectionEvaluator:
             if gt_concepts.strip() == '':
                 gt_concepts = []
             else:
-                gt_concepts = gt_concepts.split(',')
+                gt_concepts = gt_concepts.split(';')
 
             if candidate_concepts.strip() == '':
                 candidate_concepts = []
             else:
-                candidate_concepts = candidate_concepts.split(',')
+                candidate_concepts = candidate_concepts.split(';')
 
             # Manage empty GT concepts (ignore in evaluation)
             if len(gt_concepts) == 0:


### PR DESCRIPTION
In the 2018 edition of concept detection, submission files have lists of concepts separated by semi-colons. They used to be comma separated in 2017, but it seems that `f1_compute` was not updated with this change.